### PR TITLE
Unassisted promotion via ftp custom command PROM <vpkpath>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.a
+/eboot.bin
+*.elf
+*.sfo
+*.velf
+*.vpk

--- a/main.c
+++ b/main.c
@@ -1371,9 +1371,6 @@ void getNetInfo() {
 	}
 }
 
-void ftpvita_PROM_done(void *_client) {
-}
-
 void ftpvita_PROM(ftpvita_client_info_t *client) {
 	char cmd[64];
 	char path[MAX_PATH_LENGTH];
@@ -1382,8 +1379,6 @@ void ftpvita_PROM(ftpvita_client_info_t *client) {
 	InstallArguments args = {0};
 	args.file = path;
 	args.assisted = 0;
-	args.completed_callback_arg = client;
-	args.completed_callback = ftpvita_PROM_done;
 
 	closeWaitDialog();
 	dialog_step = DIALOG_STEP_NONE;
@@ -1399,7 +1394,6 @@ void ftpvita_PROM(ftpvita_client_info_t *client) {
 
 		initMessageDialog(SCE_MSG_DIALOG_BUTTON_TYPE_OK_CANCEL, language_container[FTP_SERVER], vita_ip, vita_port);
 		dialog_step = DIALOG_STEP_FTP;
-		ctx_menu_mode = CONTEXT_MENU_OPENED;
 	}
 }
 

--- a/main.h
+++ b/main.h
@@ -197,5 +197,8 @@ void drawShellInfo(char *path);
 
 int isInArchive();
 
+void ftpvita_PROM(ftpvita_client_info_t *client);
+void install_unassisted_sync(char *path);
+
 #endif
 

--- a/package_installer.c
+++ b/package_installer.c
@@ -322,9 +322,5 @@ EXIT:
 	// Unlock power timers
 	powerUnlock();
 
-	if (args->completed_callback != NULL) {
-		args->completed_callback(args->completed_callback_arg);
-	}
-
 	return sceKernelExitDeleteThread(0);
 }

--- a/package_installer.h
+++ b/package_installer.h
@@ -27,6 +27,9 @@
 
 typedef struct {
 	char *file;
+	int assisted;
+	void *completed_callback_arg;
+	void (*completed_callback)(void*);
 } InstallArguments;
 
 int promote(char *path);

--- a/package_installer.h
+++ b/package_installer.h
@@ -28,8 +28,6 @@
 typedef struct {
 	char *file;
 	int assisted;
-	void *completed_callback_arg;
-	void (*completed_callback)(void*);
 } InstallArguments;
 
 int promote(char *path);


### PR DESCRIPTION
This PR is related to this issue:
https://github.com/TheOfficialFloW/VitaShell/issues/38

Requires lastest version of libftpvita, that is already merged:
https://github.com/xerpi/libftpvita/pull/16

It is supported in already released VitaOrganizer 0.2:
https://github.com/soywiz/vitaorganizer/
https://github.com/soywiz/vitaorganizer/releases/download/0.2/vitaorganizer-0.2.jar

There is a small minor issue, that after promoting, it doesn't display again the ftp popup.
Tried with this:
```
initMessageDialog(SCE_MSG_DIALOG_BUTTON_TYPE_OK_CANCEL, language_container[FTP_SERVER], vita_ip, vita_port);
dialog_step = DIALOG_STEP_FTP;
```

But was not enough.