### PR TITLE
Enabling ftp activates powerlock, but activating a game from ftp, lau…

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -109,7 +109,7 @@ void infoDialog(char *msg, ...) {
 
 int power_tick_thread(SceSize args, void *argp) {
 	while (1) {
-		if (lock_power) {
+		if (lock_power > 0) {
 			sceKernelPowerTick(SCE_KERNEL_POWER_TICK_DISABLE_AUTO_SUSPEND);
 		}
 
@@ -126,11 +126,12 @@ void initPowerTickThread() {
 }
 
 void powerLock() {
-	lock_power = 1;
+	lock_power++;
 }
 
 void powerUnlock() {
-	lock_power = 0;
+	lock_power--;
+	if (lock_power < 0) lock_power = 0;
 }
 
 void readPad() {


### PR DESCRIPTION
Enabling ftp activates powerlock, but activating a game from ftp, launches package_installer that after ending, disables the powertick even when ftp has activated it.

So instead of setting to 0 or 1, powerLock/powerUnlock will act as increment/decrement.
It should work as far as you call unlock after locking (which is the case right now as far as i have seen).