### PR TITLE
fix compile error

### DIFF
--- a/package_installer.c
+++ b/package_installer.c
@@ -183,9 +183,7 @@ int promoteApp(char *path) {
 int deleteApp(char *titleid) {
 	int res;
 
-	char temp[0x100];
-
-	res = _sceAppMgrDestroyAppByName(titleid, temp);
+	res = _sceAppMgrDestroyAppByName(titleid);
 	if (res < 0 && res != 0x80802012)
 		return res;
 


### PR DESCRIPTION
vita-header declare function signature :
int _sceAppMgrDestroyAppByName(char *name);

see:
https://github.com/vitasdk/vita-headers/blob/e9ec687c2052d0fc40a2e2f307b2a16a843d8fa0/include/psp2/appmgr.h#L74