### PR TITLE
cmake files fixes for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,11 @@ cmake_minimum_required (VERSION 3.1.0 FATAL_ERROR)
 
 ###### begin vitasdk setup ######
 
-SET(VITASDK $ENV{VITASDK})
+if (WIN32)
+set (EXECUTABLE_SUFFIX ".exe")
+endif ()
+
+SET(VITASDK $ENV{VITASDK} CACHE PATH "VitaSDK path" FORCE)
 
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR arm)
@@ -11,11 +15,9 @@ SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 SET(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
 SET(CMAKE_VITA_PREFIX ${VITASDK}/bin/arm-vita-eabi)
-set(CMAKE_C_COMPILER ${CMAKE_VITA_PREFIX}-gcc)
-set(CMAKE_CXX_COMPILER ${CMAKE_VITA_PREFIX}-g++)
-set(CMAKE_STRIP ${CMAKE_VITA_PREFIX}-strip CACHE FILEPATH "VitaSDK toolchain stripper" FORCE)
-set(CMAKE_LD ${CMAKE_VITA_PREFIX}-ld CACHE FILEPATH "VitaSDK toolchain linker" FORCE)
-set(CMAKE_AR ${CMAKE_VITA_PREFIX}-ar CACHE FILEPATH "VitaSDK toolchain archiver" FORCE)
+set(CMAKE_C_COMPILER ${CMAKE_VITA_PREFIX}-gcc${EXECUTABLE_SUFFIX})
+set(CMAKE_CXX_COMPILER ${CMAKE_VITA_PREFIX}-g++${EXECUTABLE_SUFFIX})
+set(CMAKE_LD ${CMAKE_VITA_PREFIX}-ld${EXECUTABLE_SUFFIX})
 ###### end vitasdk setup ######
 
 ##### begin project setup ######
@@ -155,7 +157,7 @@ foreach(res ${PROJECT_RESOURCES})
 	string(REPLACE "." "_" res_obj ${res})
 	add_custom_command(
 			OUTPUT ${res_obj}.o
-			COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${CMAKE_LD} -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${res_obj}.o resources/${res}
+			COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_LD} -r -b binary -o ${CMAKE_CURRENT_BINARY_DIR}/${res_obj}.o resources/${res}
 	)
 	target_sources(${PROJECT_TITLE}.elf PUBLIC ${res_obj}.o)
 endforeach(res)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ endforeach(json)
 
 add_custom_command(
 		OUTPUT ${PROJECT_TITLE}.velf
-		COMMAND vita-elf-create ${PROJECT_TITLE}.elf ${PROJECT_TITLE}.velf ${__PROJECT_EXTRA_JSON__}
+		COMMAND ${VITASDK}/bin/vita-elf-create ${PROJECT_TITLE}.elf ${PROJECT_TITLE}.velf ${__PROJECT_EXTRA_JSON__}
 		DEPENDS ${PROJECT_TITLE}.elf
 )
 add_custom_target(
@@ -192,7 +192,7 @@ add_custom_target(
 
 add_custom_command(
 		OUTPUT eboot.bin
-		COMMAND vita-make-fself ${PROJECT_TITLE}.velf eboot.bin
+		COMMAND ${VITASDK}/bin/vita-make-fself ${PROJECT_TITLE}.velf eboot.bin
 		DEPENDS ${PROJECT_TITLE}.velf
 )
 add_custom_target(
@@ -202,7 +202,7 @@ add_custom_target(
 
 add_custom_command(
 		OUTPUT param.sfo
-		COMMAND vita-mksfoex -s TITLE_ID="${PROJECT_TITLEID}" "${PROJECT_TITLE}" param.sfo
+		COMMAND ${VITASDK}/bin/vita-mksfoex -s TITLE_ID="${PROJECT_TITLEID}" "${PROJECT_TITLE}" param.sfo
 )
 add_custom_target(
 		sfo
@@ -211,7 +211,7 @@ add_custom_target(
 
 add_custom_command(
 		OUTPUT ${PROJECT_TITLE}.vpk
-		COMMAND vita-pack-vpk -s param.sfo -b eboot.bin ${__PACK_ASSETS_COMMAND__} ${PROJECT_TITLE}.vpk
+		COMMAND ${VITASDK}/bin/vita-pack-vpk -s param.sfo -b eboot.bin ${__PACK_ASSETS_COMMAND__} ${PROJECT_TITLE}.vpk
 		DEPENDS eboot.bin
 		DEPENDS param.sfo
 )

--- a/libpromoter/CMakeLists.txt
+++ b/libpromoter/CMakeLists.txt
@@ -4,18 +4,17 @@ execute_process(COMMAND ${VITASDK}/bin/vita-libs-gen ${CMAKE_CURRENT_SOURCE_DIR}
 
 file(GLOB AS_FILES ${CMAKE_CURRENT_BINARY_DIR}/build_libs/*.S)
 
-set(AS_COMMAND true)
-set(AR_COMMAND ${CMAKE_VITA_PREFIX}-ar cru ${TARGETLIB})
+set(AS_OBJS)
 foreach(file ${AS_FILES})
     get_filename_component(name ${file} NAME_WE)
-    list(APPEND AS_COMMAND && ${CMAKE_VITA_PREFIX}-as ${file} -o ${name}.o)
-    list(APPEND AR_COMMAND ${name}.o)
+    add_custom_command(OUTPUT ${name}.o COMMAND ${CMAKE_VITA_PREFIX}-as ${file} -o ${name}.o)
+    list(APPEND AS_OBJS ${name}.o)
 endforeach(file)
 
 add_custom_command(OUTPUT ${TARGETLIB}
-    COMMAND ${AS_COMMAND}
-    COMMAND ${AR_COMMAND}
+    COMMAND ${CMAKE_VITA_PREFIX}-ar cru ${TARGETLIB} ${AS_OBJS}
     COMMAND ${CMAKE_VITA_PREFIX}-ranlib ${TARGETLIB}
+    DEPENDS ${AS_OBJS}
 )
 
 add_custom_target(libpromoter_target DEPENDS ${TARGETLIB})


### PR DESCRIPTION
Ninja generator is still not working under MSYS shell. I found this issue was mentioned in its official discussions but no solution was supplied, so I have no idea to fix it.
Anywayz, by this change no MSYS shell(devkitpro/MSYS2/...) but only VitaSDK itself is needed for compiling VitaShell on Windows, thus Eclipse/Sublime/CLion can be used to work on VitaShell.
CMAKE_AR/CMAKE_STRIP are also removed as they are never used and is generated automatically indeed.