### PR TITLE
Add lrc support and RegEx lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TITLE_ID = VITASHELL
 TARGET   = VitaShell
 OBJS     = main.o init.o io_process.o package_installer.o network_update.o context_menu.o archive.o photo.o audioplayer.o file.o text.o hex.o sfo.o \
 		   uncommon_dialog.o message_dialog.o ime_dialog.o config.o theme.o language.o utils.o sha1.o list_dialog.o \
-		   minizip/unzip.o minizip/ioapi.o bm.o audio/vita_audio.o audio/player.o audio/id3.o audio/oggplayer.o audio/mp3player.o audio/mp3xing.o \
+		   minizip/unzip.o minizip/ioapi.o bm.o audio/vita_audio.o audio/player.o audio/id3.o audio/oggplayer.o audio/mp3player.o audio/mp3xing.o audio/lrcparse.o\
 		   libmad/bit.o libmad/decoder.o libmad/fixed.o libmad/frame.o \
 		   libmad/huffman.o libmad/layer12.o libmad/layer3.o  \
 		   libmad/stream.o libmad/synth.o libmad/timer.o
@@ -14,7 +14,7 @@ RESOURCES_BIN := $(foreach dir,$(RESOURCES), $(wildcard $(dir)/*.bin))
 
 OBJS += $(RESOURCES_PNG:.png=.o) $(RESOURCES_TXT:.txt=.o) $(RESOURCES_BIN:.bin=.o)
 
-LIBS = -lvorbisfile -logg -lvorbis -lftpvita -lvita2d -lpng -ljpeg -lz -lm -lc \
+LIBS = -lvorbisfile -logg -lvorbis -lftpvita -lvita2d -lpng -ljpeg -lz -lm -lc -lonig \
 	   -lSceAppMgr_stub -lSceAppUtil_stub -lSceCommonDialog_stub \
 	   -lSceCtrl_stub -lSceDisplay_stub -lSceGxm_stub -lSceIme_stub \
 	   -lSceHttp_stub -lSceKernel_stub -lSceMusicExport_stub -lSceNet_stub -lSceNetCtl_stub \

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Be sure you pull request your customized design or language file there.
 * vita2dlib: https://github.com/xerpi/vita2dlib
 * ftpvitalib https://github.com/xerpi/ftpvitalib
 * EasyRPG libraries: https://ci.easyrpg.org/view/Toolchains/job/toolchain-vita/
+* Onigmo library https://github.com/k-takata/Onigmo
 
 ### Credits ###
 * Team Molecule for HENkaku

--- a/audio/lrcparse.c
+++ b/audio/lrcparse.c
@@ -1,0 +1,119 @@
+/*
+	VitaShell
+	Copyright (C) 2015-2016, TheFloW
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "lrcparse.h"
+
+static char* getStringFromRegmatch(char* source,size_t so,size_t eo)
+{
+    size_t wordlength = eo - so;
+    char* word;
+
+    if(wordlength < 2){
+        word = malloc(sizeof(char));
+        word[0] = '\0';
+    }else{
+        word = malloc(sizeof(char) * (wordlength + 1));
+        memcpy((void*)word,(void*)source + so,wordlength);//copy string
+        word[sizeof(char) * (wordlength)] = '\0';
+    }
+    return word;
+}
+
+Lyrics* lrcParseLoadWithFile(char* lrcfilepath)
+{
+    int filesize = getFileSize(lrcfilepath);
+
+    if(filesize < 0)
+        return NULL;
+
+    char lrcbuffer[filesize];
+
+    if(ReadFile(lrcfilepath,(void*)lrcbuffer,filesize) < 0)
+        return NULL;
+
+    return lrcParseLoadWithBuffer(lrcbuffer);
+}
+
+Lyrics* lrcParseLoadWithBuffer(char* buffer)
+{
+    regmatch_t pm[5];
+    regex_t preg;
+
+    char* pattern = "\\[([0-9]{2}):([0-5][0-9])\\.([0-9]{2})\\](.*)";
+
+    if (regcomp(&preg, pattern, REG_EXTENDED |REG_NEWLINE) != 0)
+        return NULL;
+
+    uint32_t lines = 0;//lyrics line count
+
+    Lyricsline* lrcline = malloc(sizeof(Lyricsline) * MAX_LYRICSLINE);
+
+    while(1){
+        if(regexec(&preg,buffer, 5, pm, REG_NOTEOL) != REG_NOMATCH){
+
+            char* m = getStringFromRegmatch(buffer,pm[1].rm_so,pm[1].rm_eo);
+            char* s = getStringFromRegmatch(buffer,pm[2].rm_so,pm[2].rm_eo);
+            char* ms = getStringFromRegmatch(buffer,pm[3].rm_so,pm[3].rm_eo);
+            char* word = getStringFromRegmatch(buffer,pm[4].rm_so,pm[4].rm_eo);
+
+
+            lrcline[lines].m = atol(m);
+            lrcline[lines].s = atoi(s);
+            lrcline[lines].ms = atoi(ms);
+            lrcline[lines].word = word;
+            lrcline[lines].totalms = (atol(m) * 60 + atoi(s)) * 1000 + atoi(ms) * 10;
+
+            free(m);
+            free(s);
+            free(ms);
+
+            lines++;
+            buffer+=pm[0].rm_eo;
+        }else{break;}
+    }
+
+    regfree(&preg);
+
+    Lyrics* lyrics = malloc(sizeof(Lyrics));
+    lyrics->lrclines = lrcline;
+    lyrics->lyricscount = lines;
+
+    return lyrics;
+}
+
+void lrcParseClose(Lyrics* lyrics)
+{
+    if(!lyrics)
+        return;
+
+    lyrics->lyricscount = 0;
+    int i;
+    for(i = 0;i < lyrics->lyricscount ; ++i){
+        if(lyrics->lrclines[i].word){
+            free(lyrics->lrclines[i].word);//free lyrics words
+            lyrics->lrclines[i].word = NULL;
+        }
+    }
+
+    if(lyrics->lrclines){
+        free(lyrics->lrclines);//free lrclines struct
+        lyrics->lrclines = NULL;
+    }
+
+    free(lyrics);//free lyrics
+    lyrics = NULL;
+}

--- a/audio/lrcparse.h
+++ b/audio/lrcparse.h
@@ -1,0 +1,77 @@
+/*
+	VitaShell
+	Copyright (C) 2015-2016, TheFloW
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __LRCPARSE_H__
+#define __LRCPARSE_H__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <psp2/types.h>
+#include <onigposix.h>
+#include "../file.h"
+
+#define MAX_LYRICSLINE 512
+
+/** struct for a line lyrics */
+typedef struct {
+    uint64_t totalms;///< total millisecond
+    uint32_t m; ///< minute
+    uint8_t s; ///< second
+    uint8_t ms; ///< millisecond
+    char* word; ///< lyrics words
+}Lyricsline;
+
+/** struct for lyrics */
+typedef struct{
+    size_t lyricscount;///< lyrics line count
+    Lyricsline* lrclines;///< lyrics line
+}Lyrics;
+
+
+
+/**
+* init from lrc file path
+* @param[in] lrcfilepath lrc file path
+* @return lyrics struct
+* @ref file.h
+* @see
+* @note
+*/
+Lyrics* lrcParseLoadWithFile(char* lrcfilepath);
+
+/**
+* init from buffer
+* @param[in] buffer lrcbuffer
+* @return lyrics struct
+* @see
+* @note
+*/
+Lyrics* lrcParseLoadWithBuffer(char* buffer);
+
+/**
+* close lrcparse
+* @param[in] lyrics
+* @see
+* @note You must use this function to free lrcparse malloc memory!
+*/
+void lrcParseClose(Lyrics* lyrics);
+
+
+#endif

--- a/audioplayer.c
+++ b/audioplayer.c
@@ -23,12 +23,102 @@
 #include "theme.h"
 #include "language.h"
 #include "utils.h"
+#include "audio/lrcparse.h"
 
 #include "audio/player.h"
 
 static char title[128], album[128], artist[128], genre[128], year[12];
 static struct fileInfo *fileinfo = NULL;
 static vita2d_texture *tex = NULL;
+
+
+/**
+* Calculate the x-axis position if draw text in center
+* @param[in] sx start x-axis
+* @param[in] ex end x-axis
+* @param[in] text
+* @return x-axis position
+*/
+float getCenteroffset(float sx,float ex,char* string){
+    if(!string||(string[0] == '\0'))
+        return sx;
+
+    float drawWidthSpace = ex - sx;
+    uint16_t stringWidth = vita2d_pgf_text_width(font,FONT_SIZE,string);
+    return stringWidth > drawWidthSpace ? sx : sx + (drawWidthSpace - stringWidth) / 2 ;
+}
+
+/**
+* Try to load lrc file from audio path
+* @param[in] path audio path
+* @param[out] totalms set 0
+* @param[out] lyricsIndex set 0
+* @return Lyrics pointer , NULL is fail
+*/
+Lyrics* loadLyricsFile(char* path,uint64_t* totalms,uint32_t* lyricsIndex){
+    size_t pathlength = strlen(path);
+    *totalms = *lyricsIndex = 0;
+
+    while(pathlength > 0){
+        if(path[pathlength] == '.'){
+            break;
+        }
+        pathlength--;
+    }
+
+    if(pathlength < 0)
+        return NULL;
+
+    char lrcPath[pathlength + 5 * sizeof(char)];
+    memccpy(lrcPath,path,sizeof(char),pathlength);//copy path string except filename extension
+    strcpy(lrcPath+pathlength,".lrc");
+
+    return lrcParseLoadWithFile(lrcPath);
+}
+
+/**
+* Draw the lyrics from the designated area
+* @param[in] lyrics Lyrics pointer
+* @param[in] cur_time_string Playing time string
+* @param[out] totalms Playing time (millisecond)
+* @param[out] lyricsIndex Index of lyrics
+* @param[in] lrcSpaceX Designated area starting point x
+* @param[in] lrcSpaceX Designated area starting point y
+*/
+void drawLyrics(Lyrics* lyrics,char* cur_time_string,uint64_t* totalms,uint32_t* lyricsIndex,float lrcSpaceX,float lrcSpaceY){
+    if(!lyrics)
+        return;
+
+    char hourString[3];
+    char minuteString[3];
+    char secondString[3];
+
+    strncpy(hourString,cur_time_string,sizeof(hourString));
+    strncpy(minuteString,cur_time_string + 3,sizeof(minuteString));
+    strncpy(secondString,cur_time_string + 6,sizeof(secondString));
+
+    *totalms = (((atoi(hourString) * 60) + atoi(minuteString)) * 60 + atoi(secondString)) * 1000;
+
+    uint32_t m_index = *lyricsIndex >= 1 ? (*lyricsIndex - 1) : *lyricsIndex;
+    float right_max_x = SCREEN_WIDTH - SHELL_MARGIN_X;
+    //draw current lyrics
+    pgf_draw_textf(getCenteroffset(lrcSpaceX,right_max_x,lyrics->lrclines[m_index].word),lrcSpaceY, AUDIO_INFO_ASSIGN, FONT_SIZE, "%s",lyrics->lrclines[m_index].word);
+
+    int i;
+    for(i = 1;i < 7; i++){//draw 6 line lyrics for preview
+        int n_index = m_index + i;
+        if(n_index + 1 > lyrics->lyricscount)
+            break;
+        pgf_draw_textf(getCenteroffset(lrcSpaceX,right_max_x,lyrics->lrclines[n_index].word),lrcSpaceY + FONT_Y_SPACE * i, AUDIO_INFO, FONT_SIZE, "%s",lyrics->lrclines[n_index].word);
+    }
+
+    if( *totalms >= (lyrics->lrclines[*lyricsIndex].totalms) ){
+        *lyricsIndex = *lyricsIndex + 1;
+    }else
+    if (( *lyricsIndex >= 1 ) & ( *totalms < (lyrics->lrclines[*lyricsIndex - 1].totalms ))){
+        *lyricsIndex = *lyricsIndex - 1;
+    }
+}
 
 void shortenString(char *out, char *in, int width) {
 	strcpy(out, in);
@@ -135,6 +225,11 @@ int audioPlayer(char *file, int type, FileList *list, FileListEntry *entry, int 
 
 	getAudioInfo(file);
 
+	uint64_t totalms = 0;
+	uint32_t lyricsIndex = 0;
+	Lyrics* lyrics = loadLyricsFile(file,&totalms,&lyricsIndex);
+
+
 	while (1) {
 		char cur_time_string[12];
 		getTimeStringFunct(cur_time_string);
@@ -195,12 +290,16 @@ int audioPlayer(char *file, int type, FileList *list, FileListEntry *entry, int 
 		if (getPercentageFunct() == 100.0f || endOfStreamFunct() || pressed_buttons & SCE_CTRL_LTRIGGER || pressed_buttons & SCE_CTRL_RTRIGGER) {
 			int previous = pressed_buttons & SCE_CTRL_LTRIGGER;
 			if (previous && strcmp(cur_time_string, "00:00:00") != 0) {
+                lrcParseClose(lyrics);
 				endFunct();
 				initFunct(0);
 				loadFunct(file);
 				playFunct();
 
 				getAudioInfo(file);
+
+				lyrics = loadLyricsFile(file,&totalms,&lyricsIndex);
+
 			} else {
 				int available = 0;
 
@@ -244,6 +343,7 @@ int audioPlayer(char *file, int type, FileList *list, FileListEntry *entry, int 
 						if (type == FILE_TYPE_MP3 || type == FILE_TYPE_OGG) {
 							file = path;
 
+							lrcParseClose(lyrics);
 							endFunct();
 
 							setAudioFunctions(type);
@@ -253,6 +353,8 @@ int audioPlayer(char *file, int type, FileList *list, FileListEntry *entry, int 
 							playFunct();
 
 							getAudioInfo(file);
+
+                            lyrics = loadLyricsFile(file,&totalms,&lyricsIndex);
 
 							available = 1;
 							break;
@@ -271,6 +373,7 @@ int audioPlayer(char *file, int type, FileList *list, FileListEntry *entry, int 
 
 		// Start drawing
 		startDrawing(bg_audio_image);
+
 
 		// Draw shell info
 		drawShellInfo(file);
@@ -302,6 +405,8 @@ int audioPlayer(char *file, int type, FileList *list, FileListEntry *entry, int 
 		pgf_draw_text(x, START_Y + (4 * FONT_Y_SPACE), AUDIO_INFO, FONT_SIZE, year);
 
 		x -= 120.0f;
+
+		drawLyrics(lyrics,cur_time_string,&totalms,&lyricsIndex,x,START_Y + (6 * FONT_Y_SPACE));
 
 		float y = SCREEN_HEIGHT - 6.0f * SHELL_MARGIN_Y;
 
@@ -348,6 +453,7 @@ int audioPlayer(char *file, int type, FileList *list, FileListEntry *entry, int 
 		tex = NULL;
 	}
 
+	lrcParseClose(lyrics);
 	endFunct();
 
 	powerUnlock();


### PR DESCRIPTION
Use regex to parse lrc file.
Although vitasdk brought posix RegEx header "regex.h",but there are no regex function in libc. So I used to want to write a parse function without RegEx.
But after,I think RegEx maybe useful in some text editing function (such as find,replace etc),and I found a library to implement it.It support multiple encodings and work very well on vita.So I still use RegEx to parse them.