### PR TITLE
fixed link dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ RESOURCES_BIN := $(foreach dir,$(RESOURCES), $(wildcard $(dir)/*.bin))
 
 OBJS += $(RESOURCES_PNG:.png=.o) $(RESOURCES_TXT:.txt=.o) $(RESOURCES_BIN:.bin=.o)
 
-LIBS = -lvorbisfile -logg -lvorbis -lftpvita -lvita2d -lpng -ljpeg -lz -lm -lc -lonig \
+LIBS = -lvorbisfile -lvorbis -logg -lftpvita -lvita2d -lpng -ljpeg -lz -lm -lc -lonig \
 	   -lSceAppMgr_stub -lSceAppUtil_stub -lSceCommonDialog_stub \
 	   -lSceCtrl_stub -lSceDisplay_stub -lSceGxm_stub -lSceIme_stub \
 	   -lSceHttp_stub -lSceKernel_stub -lSceMusicExport_stub -lSceNet_stub -lSceNetCtl_stub \


### PR DESCRIPTION
ld.gold under linux requires dependencies to be ordered correctly for symbols search, this problem occurs when some system cannot link libvorbis.la correctly so that it cannot find -logg in libvorbis.la and put another -logg behind