### PR TITLE
Support safety checking compressed fself

### DIFF
--- a/archive.c
+++ b/archive.c
@@ -20,6 +20,7 @@
 #include "archive.h"
 #include "file.h"
 #include "utils.h"
+#include "elf.h"
 
 #include "minizip/unzip.h"
 
@@ -28,7 +29,8 @@ static unzFile uf = NULL;
 static FileList archive_list;
 
 int checkForUnsafeImports(void *buffer);
-char *uncompressBuffer(const char *hdr, const char *buffer);
+char *uncompressBuffer(const Elf32_Ehdr *ehdr, const Elf32_Phdr *phdr, const segment_info *segment,
+		       const char *buffer);
 
 int archiveCheckFilesForUnsafeFself() {
 	if (!uf)
@@ -52,6 +54,8 @@ int archiveCheckFilesForUnsafeFself() {
 				archiveFileRead(ARCHIVE_FD, sce_header, sizeof(sce_header));
 
 				uint64_t elf1_offset = *(uint64_t *)(sce_header + 0x3C);
+				uint64_t phdr_offset = *(uint64_t *)(sce_header + 0x44);
+				uint64_t section_info_offset = *(uint64_t *)(sce_header + 0x54);
 
 				int i;
 				// jump to elf1
@@ -63,15 +67,20 @@ int archiveCheckFilesForUnsafeFself() {
 
 				// ELF header starts at header_len, so let's seek to there
 				uint64_t header_len = *(uint64_t *)(sce_header + 0xC);
-				char elf1_header[header_len - elf1_offset];
-				archiveFileRead(ARCHIVE_FD, elf1_header, header_len - elf1_offset);
+				char elf1[header_len - elf1_offset];
+				archiveFileRead(ARCHIVE_FD, elf1, header_len - elf1_offset);
 
 				// Check imports
 				char *buffer = malloc(archive_entry->size);
 				if (buffer) {
 					int size = archiveFileRead(ARCHIVE_FD, buffer, archive_entry->size);
 					if (buffer[0] == 0x78) {
-						char *uncompressed_buffer = uncompressBuffer(elf1_header, buffer);
+						char *uncompressed_buffer = uncompressBuffer(
+							(Elf32_Ehdr*)elf1,
+							(Elf32_Phdr*)(elf1 + phdr_offset - elf1_offset),
+							(segment_info*)(elf1 + section_info_offset - elf1_offset),
+							buffer
+						);
 						if (uncompressed_buffer) {
 							free(buffer);
 							buffer = uncompressed_buffer;

--- a/elf.c
+++ b/elf.c
@@ -150,14 +150,8 @@ int checkForUnsafeImports(void *buffer) {
 	return 0; // Safe
 }
 
-char *uncompressBuffer(const char *hdr, const char *buffer) {
-	// 0xa0 ~ 0xa0 + sizeof(Elf32_Ehdr)
-	Elf32_Ehdr *ehdr = (Elf32_Ehdr *)hdr;
-	// ehdr + padding(uint32_t[3])
-	Elf32_Phdr *phdr = (Elf32_Phdr *)(hdr + sizeof(Elf32_Ehdr) + sizeof(uint32_t) * 3);
-	// phdr + sizeof(phdr) * phdr_num
-	segment_info *segment = (segment_info*)((char*)phdr + sizeof(Elf32_Phdr) * ehdr->e_phnum);
-
+char *uncompressBuffer(const Elf32_Ehdr *ehdr, const Elf32_Phdr *phdr, const segment_info *segment,
+		       const char *buffer) {
 	if (ehdr->e_ident[EI_MAG0] != ELFMAG0 ||
 	    ehdr->e_ident[EI_MAG1] != ELFMAG1 ||
 	    ehdr->e_ident[EI_MAG2] != ELFMAG2 ||

--- a/elf.h
+++ b/elf.h
@@ -411,6 +411,12 @@ typedef struct {
 #define R_ARM_THM_MOVW_ABS_NC   47
 #define R_ARM_THM_MOVT_ABS      48
 
+typedef struct {
+	uint64_t offset;
+	uint64_t length;
+	uint64_t compression; // 1 = uncompressed, 2 = compressed
+	uint64_t encryption; // 1 = encrypted, 2 = plain
+} segment_info;
 
 /* Functions */
 


### PR DESCRIPTION
new vita-toolchain added fself binary compression.
but this feature also compress `ELF` header and NID information
so, we need to uncompress datas for safety checking

https://github.com/vitasdk/vita-toolchain/pull/90