### PR TITLE
Fix onigmo libname and header filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RESOURCES_BIN := $(foreach dir,$(RESOURCES), $(wildcard $(dir)/*.bin))
 
 OBJS += $(RESOURCES_PNG:.png=.o) $(RESOURCES_TXT:.txt=.o) $(RESOURCES_BIN:.bin=.o)
 
-LIBS = -lvorbisfile -lvorbis -logg -lftpvita -lvita2d -lpng -ljpeg -lz -lm -lc -lonig \
+LIBS = -lvorbisfile -lvorbis -logg -lftpvita -lvita2d -lpng -ljpeg -lz -lm -lc -lonigmo \
 	   -lSceAppMgr_stub -lSceAppUtil_stub -lSceAudio_stub -lSceAudiodec_stub \
 	   -lSceCommonDialog_stub -lSceCtrl_stub -lSceDisplay_stub -lSceGxm_stub -lSceIme_stub \
 	   -lSceHttp_stub -lSceMusicExport_stub -lSceNet_stub -lSceNetCtl_stub -lSceShellSvc_stub \

--- a/audio/lrcparse.h
+++ b/audio/lrcparse.h
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <psp2/types.h>
-#include <onigposix.h>
+#include <onigmoposix.h>
 #include "../file.h"
 
 #define MAX_LYRICSLINE 512


### PR DESCRIPTION
9 days ago, onigmo master tree merged from devel-6.0

https://github.com/k-takata/Onigmo/commit/09ab902fdd