### PR TITLE
sceRegMgrGetKeyBin already defined in VITASDK

### DIFF
--- a/main.h
+++ b/main.h
@@ -35,6 +35,7 @@
 #include <psp2/power.h>
 #include <psp2/promoterutil.h>
 #include <psp2/rtc.h>
+#include <psp2/registrymgr.h>
 #include <psp2/shellutil.h>
 #include <psp2/sysmodule.h>
 #include <psp2/system_param.h>

--- a/refresh.c
+++ b/refresh.c
@@ -41,7 +41,6 @@ int isCustomHomebrew() {
 	return 1;
 }
 
-int sceRegMgrGetKeyBin(const char *category, const char *name, void *buf, int size);
 int _sceNpDrmGetRifName(char *rif_name, int flags, uint64_t aid);
 int _sceNpDrmGetFixedRifName(char *rif_name, int flags, uint64_t aid);
 


### PR DESCRIPTION
sceRegMgrGetKeyBin has already defined in VITASDK, we no longer need to
redfine it. <psp2/registrymgr.h>, has access to both the regMgr get/set
functions.
