### PR TITLE
Display '0x' for hexa values in the SFO reader

### DIFF
--- a/sfo.c
+++ b/sfo.c
@@ -194,7 +194,7 @@ int SFOReader(const char *file) {
 					break;
 					
 				case PSF_TYPE_VAL:
-					snprintf(string, sizeof(string), "%X", *(unsigned int *)data);
+					snprintf(string, sizeof(string), "0x%X", *(unsigned int *)data);
 					break;
 			}
 


### PR DESCRIPTION
Otherwise it can often be mistaken for a decimal number.