### PR TITLE
add host0 support

### DIFF
--- a/file.c
+++ b/file.c
@@ -37,6 +37,7 @@ static char *devices[] = {
 	"ux0:",
 	"vd0:",
 	"vs0:",
+	"host0:",
 };
 
 #define N_DEVICES (sizeof(devices) / sizeof(char **))


### PR DESCRIPTION
This PR add host0 support for my usbhostfs port to the ps vita (https://github.com/Cpasjuste/usbhostfs) and psp2shell usb (https://github.com/Cpasjuste/psp2shell/tree/usb, wip).