### PR TITLE
add xmc0: and 2 possibly useful additions

### DIFF
--- a/file.c
+++ b/file.c
@@ -39,7 +39,10 @@ static char *devices[] = {
   "ux0:",
   "vd0:",
   "vs0:",
+  "xmc0:", //missing partition, similar to uma0:
   "host0:",
+/*  "app0:", //actually has a use, injecting latest vitashell to system apps if injectors break
+  "savedata0:", //use for backing up important files to where a user wont accidentally delete? or move vitashell config to here?*/
 };
 
 #define N_DEVICES (sizeof(devices) / sizeof(char **))

--- a/file.c
+++ b/file.c
@@ -25,12 +25,14 @@
 #include "strnatcmp.h"
 
 static char *devices[] = {
+//  "app0:", //actually has a use, injecting latest vitashell to system apps if injectors break
   "gro0:",
   "grw0:",
   "imc0:",
   "os0:",
   "pd0:",
   "sa0:",
+//  "savedata0:", //use for backing up important files to where a user wont accidentally delete? or move vitashell config to here?
   "sd0:",
   "tm0:",
   "ud0:",
@@ -41,8 +43,6 @@ static char *devices[] = {
   "vs0:",
   "xmc0:", //missing partition, similar to uma0:
   "host0:",
-/*  "app0:", //actually has a use, injecting latest vitashell to system apps if injectors break
-  "savedata0:", //use for backing up important files to where a user wont accidentally delete? or move vitashell config to here?*/
 };
 
 #define N_DEVICES (sizeof(devices) / sizeof(char **))


### PR DESCRIPTION
xmc0: is similar to uma0: i use it for my sd2vita because it fits better
uma0: is usbmass so for people who dont use a sd2vita as ux0: external memcard is better fitting

also added back app0: and savedata0: in comments because those do have a use in vitashell but i dont think everyone would have the same use
savedata0: could be pretty useful for vitashell to use
but app0: would only be useful for people who need fast access to ux0:app/VITASHELL/ but have alot of apps installed on ux0:
left both in comments so you can decide for yourself wether they are useful or not