### PR TITLE
Finished "Refresh LiveArea" function rework, added patches support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ endif()
 # Project start
 project(VitaShell)
 include("${VITASDK}/share/vita.cmake" REQUIRED)
-set(VITA_APP_NAME "Promo Test")
-set(VITA_TITLEID  "VITASHEL2")
+set(VITA_APP_NAME "VitaShell")
+set(VITA_TITLEID  "VITASHELL")
 set(VITA_VERSION  "01.97")
 
 # Flags and includes
@@ -215,7 +215,7 @@ vita_create_vpk(VitaShell.vpk ${VITA_TITLEID} eboot.bin
 add_custom_target(release
   COMMAND cp eboot.bin ../release/eboot.bin
   COMMAND cp VitaShell.vpk_param.sfo ../release/param.sfo
-  COMMAND cp VitaShell.vpk ../release/VitaShell_promo.vpk
+  COMMAND cp VitaShell.vpk ../release/VitaShell.vpk
   COMMAND cp ../pkg/sce_sys/livearea/contents/template.xml ../release/template.xml
   DEPENDS eboot.bin
   DEPENDS VitaShell.vpk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ endif()
 # Project start
 project(VitaShell)
 include("${VITASDK}/share/vita.cmake" REQUIRED)
-set(VITA_APP_NAME "VitaShell")
-set(VITA_TITLEID  "VITASHELL")
+set(VITA_APP_NAME "Promo Test")
+set(VITA_TITLEID  "VITASHEL2")
 set(VITA_VERSION  "01.97")
 
 # Flags and includes
@@ -79,6 +79,7 @@ add_resources(vitashell_res
 add_executable(VitaShell
   ${vitashell_res}
   main.c
+  pfs.c
   main_context.c
   browser.c
   init.c
@@ -214,7 +215,7 @@ vita_create_vpk(VitaShell.vpk ${VITA_TITLEID} eboot.bin
 add_custom_target(release
   COMMAND cp eboot.bin ../release/eboot.bin
   COMMAND cp VitaShell.vpk_param.sfo ../release/param.sfo
-  COMMAND cp VitaShell.vpk ../release/VitaShell.vpk
+  COMMAND cp VitaShell.vpk ../release/VitaShell_promo.vpk
   COMMAND cp ../pkg/sce_sys/livearea/contents/template.xml ../release/template.xml
   DEPENDS eboot.bin
   DEPENDS VitaShell.vpk

--- a/browser.c
+++ b/browser.c
@@ -44,6 +44,7 @@
 #include "coredump.h"
 #include "usb.h"
 #include "qr.h"
+#include "pfs.h"
 
 // File lists
 FileList file_list, mark_list, copy_list, install_list;

--- a/main.c
+++ b/main.c
@@ -46,6 +46,7 @@
 #include "coredump.h"
 #include "usb.h"
 #include "qr.h"
+#include "pfs.h"
 
 int _newlib_heap_size_user = 128 * 1024 * 1024;
 

--- a/main_context.c
+++ b/main_context.c
@@ -29,10 +29,11 @@
 #include "ime_dialog.h"
 #include "utils.h"
 #include "usb.h"
+#include "pfs.h"
 
-char pfs_mounted_path[MAX_PATH_LENGTH];
-char pfs_mount_point[MAX_MOUNT_POINT_LENGTH];
-int read_only = 0;
+//char pfs_mounted_path[MAX_PATH_LENGTH];
+//char pfs_mount_point[MAX_MOUNT_POINT_LENGTH];
+//int read_only = 0;
 
 enum MenuHomeEntrys {
   MENU_HOME_ENTRY_REFRESH_LIVEAREA,
@@ -241,84 +242,84 @@ ContextMenu context_menu_new = {
   .sel = -1,
 };
 
-/*
-  SceAppMgr mount IDs:
-  0x64: ux0:picture
-  0x65: ur0:user/00/psnfriend
-  0x66: ur0:user/00/psnmsg
-  0x69: ux0:music
-  0x6E: ux0:appmeta
-  0xC8: ur0:temp/sqlite
-  0xCD: ux0:cache
-  0x12E: ur0:user/00/trophy/data/sce_trop
-  0x12F: ur0:user/00/trophy/data
-  0x3E8: ux0:app, vs0:app, gro0:app
-  0x3E9: ux0:patch
-  0x3EB: ?
-  0x3EA: ux0:addcont
-  0x3EC: ux0:theme
-  0x3ED: ux0:user/00/savedata
-  0x3EE: ur0:user/00/savedata
-  0x3EF: vs0:sys/external
-  0x3F0: vs0:data/external
-*/
+// /*
+  // SceAppMgr mount IDs:
+  // 0x64: ux0:picture
+  // 0x65: ur0:user/00/psnfriend
+  // 0x66: ur0:user/00/psnmsg
+  // 0x69: ux0:music
+  // 0x6E: ux0:appmeta
+  // 0xC8: ur0:temp/sqlite
+  // 0xCD: ux0:cache
+  // 0x12E: ur0:user/00/trophy/data/sce_trop
+  // 0x12F: ur0:user/00/trophy/data
+  // 0x3E8: ux0:app, vs0:app, gro0:app
+  // 0x3E9: ux0:patch
+  // 0x3EB: ?
+  // 0x3EA: ux0:addcont
+  // 0x3EC: ux0:theme
+  // 0x3ED: ux0:user/00/savedata
+  // 0x3EE: ur0:user/00/savedata
+  // 0x3EF: vs0:sys/external
+  // 0x3F0: vs0:data/external
+// */
 
-int known_pfs_ids[] = {
-  0x6E,
-  0x12E,
-  0x12F,
-  0x3ED,
-};
+// int known_pfs_ids[] = {
+  // 0x6E,
+  // 0x12E,
+  // 0x12F,
+  // 0x3ED,
+// };
 
-int pfsMount(const char *path) {
-  int res;
-  char work_path[MAX_PATH_LENGTH];
-  char klicensee[0x10];
-  char license_buf[0x200];
-  ShellMountIdArgs args;
+// int pfsMount(const char *path) {
+  // int res;
+  // char work_path[MAX_PATH_LENGTH];
+  // char klicensee[0x10];
+  // char license_buf[0x200];
+  // ShellMountIdArgs args;
 
-  memset(klicensee, 0, sizeof(klicensee));
+  // memset(klicensee, 0, sizeof(klicensee));
 
-/*
-  snprintf(work_path, MAX_PATH_LENGTH, "%ssce_sys/package/work.bin", path);
-  if (ReadFile(work_path, license_buf, sizeof(license_buf)) == sizeof(license_buf)) {
-    int res = shellUserGetRifVitaKey(license_buf, klicensee);
-    debugPrintf("read license: 0x%08X\n", res);
-  }
-*/
-  args.process_titleid = VITASHELL_TITLEID;
-  args.path = path;
-  args.desired_mount_point = NULL;
-  args.klicensee = klicensee;
-  args.mount_point = pfs_mount_point;
+// /*
+  // snprintf(work_path, MAX_PATH_LENGTH, "%ssce_sys/package/work.bin", path);
+  // if (ReadFile(work_path, license_buf, sizeof(license_buf)) == sizeof(license_buf)) {
+    // int res = shellUserGetRifVitaKey(license_buf, klicensee);
+    // debugPrintf("read license: 0x%08X\n", res);
+  // }
+// */
+  // args.process_titleid = VITASHELL_TITLEID;
+  // args.path = path;
+  // args.desired_mount_point = NULL;
+  // args.klicensee = klicensee;
+  // args.mount_point = pfs_mount_point;
 
-  read_only = 0;
+  // read_only = 0;
 
-  int i;
-  for (i = 0; i < sizeof(known_pfs_ids) / sizeof(int); i++) {
-    args.id = known_pfs_ids[i];
+  // int i;
+  // for (i = 0; i < sizeof(known_pfs_ids) / sizeof(int); i++) {
+    // args.id = known_pfs_ids[i];
 
-    res = shellUserMountById(&args);
-    if (res >= 0)
-      return res;
-  }
+    // res = shellUserMountById(&args);
+    // if (res >= 0)
+      // return res;
+  // }
 
-  read_only = 1;
-  return sceAppMgrGameDataMount(path, 0, 0, pfs_mount_point);
-}
+  // read_only = 1;
+  // return sceAppMgrGameDataMount(path, 0, 0, pfs_mount_point);
+// }
 
-int pfsUmount() {
-  if (pfs_mount_point[0] == 0)
-    return -1;
+// int pfsUmount() {
+  // if (pfs_mount_point[0] == 0)
+    // return -1;
 
-  int res = sceAppMgrUmount(pfs_mount_point);
-  if (res >= 0) {
-    memset(pfs_mount_point, 0, sizeof(pfs_mount_point));
-    memset(pfs_mounted_path, 0, sizeof(pfs_mounted_path));
-  }
+  // int res = sceAppMgrUmount(pfs_mount_point);
+  // if (res >= 0) {
+    // memset(pfs_mount_point, 0, sizeof(pfs_mount_point));
+    // memset(pfs_mounted_path, 0, sizeof(pfs_mounted_path));
+  // }
 
-  return res;
-}
+  // return res;
+// }
 
 void initContextMenuWidth() {
   int i;

--- a/main_context.c
+++ b/main_context.c
@@ -31,10 +31,6 @@
 #include "usb.h"
 #include "pfs.h"
 
-//char pfs_mounted_path[MAX_PATH_LENGTH];
-//char pfs_mount_point[MAX_MOUNT_POINT_LENGTH];
-//int read_only = 0;
-
 enum MenuHomeEntrys {
   MENU_HOME_ENTRY_REFRESH_LIVEAREA,
   MENU_HOME_ENTRY_REFRESH_LICENSE_DB,
@@ -241,85 +237,6 @@ ContextMenu context_menu_new = {
   .callback = contextMenuNewEnterCallback,
   .sel = -1,
 };
-
-// /*
-  // SceAppMgr mount IDs:
-  // 0x64: ux0:picture
-  // 0x65: ur0:user/00/psnfriend
-  // 0x66: ur0:user/00/psnmsg
-  // 0x69: ux0:music
-  // 0x6E: ux0:appmeta
-  // 0xC8: ur0:temp/sqlite
-  // 0xCD: ux0:cache
-  // 0x12E: ur0:user/00/trophy/data/sce_trop
-  // 0x12F: ur0:user/00/trophy/data
-  // 0x3E8: ux0:app, vs0:app, gro0:app
-  // 0x3E9: ux0:patch
-  // 0x3EB: ?
-  // 0x3EA: ux0:addcont
-  // 0x3EC: ux0:theme
-  // 0x3ED: ux0:user/00/savedata
-  // 0x3EE: ur0:user/00/savedata
-  // 0x3EF: vs0:sys/external
-  // 0x3F0: vs0:data/external
-// */
-
-// int known_pfs_ids[] = {
-  // 0x6E,
-  // 0x12E,
-  // 0x12F,
-  // 0x3ED,
-// };
-
-// int pfsMount(const char *path) {
-  // int res;
-  // char work_path[MAX_PATH_LENGTH];
-  // char klicensee[0x10];
-  // char license_buf[0x200];
-  // ShellMountIdArgs args;
-
-  // memset(klicensee, 0, sizeof(klicensee));
-
-// /*
-  // snprintf(work_path, MAX_PATH_LENGTH, "%ssce_sys/package/work.bin", path);
-  // if (ReadFile(work_path, license_buf, sizeof(license_buf)) == sizeof(license_buf)) {
-    // int res = shellUserGetRifVitaKey(license_buf, klicensee);
-    // debugPrintf("read license: 0x%08X\n", res);
-  // }
-// */
-  // args.process_titleid = VITASHELL_TITLEID;
-  // args.path = path;
-  // args.desired_mount_point = NULL;
-  // args.klicensee = klicensee;
-  // args.mount_point = pfs_mount_point;
-
-  // read_only = 0;
-
-  // int i;
-  // for (i = 0; i < sizeof(known_pfs_ids) / sizeof(int); i++) {
-    // args.id = known_pfs_ids[i];
-
-    // res = shellUserMountById(&args);
-    // if (res >= 0)
-      // return res;
-  // }
-
-  // read_only = 1;
-  // return sceAppMgrGameDataMount(path, 0, 0, pfs_mount_point);
-// }
-
-// int pfsUmount() {
-  // if (pfs_mount_point[0] == 0)
-    // return -1;
-
-  // int res = sceAppMgrUmount(pfs_mount_point);
-  // if (res >= 0) {
-    // memset(pfs_mount_point, 0, sizeof(pfs_mount_point));
-    // memset(pfs_mounted_path, 0, sizeof(pfs_mounted_path));
-  // }
-
-  // return res;
-// }
 
 void initContextMenuWidth() {
   int i;

--- a/main_context.h
+++ b/main_context.h
@@ -21,15 +21,10 @@
 
 #include "context_menu.h"
 
-extern char pfs_mounted_path[MAX_PATH_LENGTH];
-
 extern ContextMenu context_menu_home;
 extern ContextMenu context_menu_main;
 extern ContextMenu context_menu_sort;
 extern ContextMenu context_menu_more;
-
-int pfsMount(const char *path);
-int pfsUmount();
 
 void initContextMenuWidth();
 void setContextMenuHomeVisibilities();

--- a/package_installer.c
+++ b/package_installer.c
@@ -64,6 +64,10 @@ int promoteApp(const char *path) {
     return res;
 
   res = scePromoterUtilityPromotePkgWithRif(path, 1);
+  //res = scePromoterUtilityPromotePkg(path, 1); < NOTE: DONT FUCKING USE IT LMAO
+  debugPrintf("scePromoterUtilityPromotePkgWithRif_path: %s\n", path);
+  debugPrintf("scePromoterUtilityPromotePkgWithRif_res: %x\n", res);
+
   if (res < 0)
     return res;
 
@@ -123,33 +127,41 @@ int checkAppExist(const char *titleid) {
   int ret;
 
   res = loadScePaf();
+  //debugPrintf("loadScePaf(): %x\n", res);
   if (res < 0)
     return res;
 
   res = sceSysmoduleLoadModuleInternal(SCE_SYSMODULE_INTERNAL_PROMOTER_UTIL);
+  //debugPrintf("Promoter_util: %x\n", res);
   if (res < 0)
     return res;
 
   res = scePromoterUtilityInit();
+  //debugPrintf("PromoterUtilityInit(): %x\n", res);
   if (res < 0)
     return res;
 
   ret = scePromoterUtilityCheckExist(titleid, &res);
+  //debugPrintf("PromoterUtilityCheckExist: %x\n", res);
   if (res < 0)
     return res;
 
   res = scePromoterUtilityExit();
+  //debugPrintf("PromoterUtilityExit: %x\n", res);
   if (res < 0)
     return res;
 
   res = sceSysmoduleUnloadModuleInternal(SCE_SYSMODULE_INTERNAL_PROMOTER_UTIL);
+  //debugPrintf("Promoter_util_unload(): %x\n", res);
   if (res < 0)
     return res;
 
   res = unloadScePaf();
+  //debugPrintf("unloadScePaf(): %x\n", res);
   if (res < 0)
     return res;
 
+  //debugPrintf("ret: %x\n", ret);
   return ret >= 0;
 }
 

--- a/package_installer.c
+++ b/package_installer.c
@@ -64,10 +64,6 @@ int promoteApp(const char *path) {
     return res;
 
   res = scePromoterUtilityPromotePkgWithRif(path, 1);
-  //res = scePromoterUtilityPromotePkg(path, 1); < NOTE: DONT FUCKING USE IT LMAO
-  debugPrintf("scePromoterUtilityPromotePkgWithRif_path: %s\n", path);
-  debugPrintf("scePromoterUtilityPromotePkgWithRif_res: %x\n", res);
-
   if (res < 0)
     return res;
 
@@ -127,41 +123,33 @@ int checkAppExist(const char *titleid) {
   int ret;
 
   res = loadScePaf();
-  //debugPrintf("loadScePaf(): %x\n", res);
   if (res < 0)
     return res;
 
   res = sceSysmoduleLoadModuleInternal(SCE_SYSMODULE_INTERNAL_PROMOTER_UTIL);
-  //debugPrintf("Promoter_util: %x\n", res);
   if (res < 0)
     return res;
 
   res = scePromoterUtilityInit();
-  //debugPrintf("PromoterUtilityInit(): %x\n", res);
   if (res < 0)
     return res;
 
   ret = scePromoterUtilityCheckExist(titleid, &res);
-  //debugPrintf("PromoterUtilityCheckExist: %x\n", res);
   if (res < 0)
     return res;
 
   res = scePromoterUtilityExit();
-  //debugPrintf("PromoterUtilityExit: %x\n", res);
   if (res < 0)
     return res;
 
   res = sceSysmoduleUnloadModuleInternal(SCE_SYSMODULE_INTERNAL_PROMOTER_UTIL);
-  //debugPrintf("Promoter_util_unload(): %x\n", res);
   if (res < 0)
     return res;
 
   res = unloadScePaf();
-  //debugPrintf("unloadScePaf(): %x\n", res);
   if (res < 0)
     return res;
 
-  //debugPrintf("ret: %x\n", ret);
   return ret >= 0;
 }
 

--- a/pfs.c
+++ b/pfs.c
@@ -1,0 +1,99 @@
+/*
+  VitaShell
+  Copyright (C) 2015-2018, TheFloW
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "main.h"
+#include "pfs.h"
+
+/*
+  SceAppMgr mount IDs:
+  0x64: ux0:picture
+  0x65: ur0:user/00/psnfriend
+  0x66: ur0:user/00/psnmsg
+  0x69: ux0:music
+  0x6E: ux0:appmeta
+  0xC8: ur0:temp/sqlite
+  0xCD: ux0:cache
+  0x12E: ur0:user/00/trophy/data/sce_trop
+  0x12F: ur0:user/00/trophy/data
+  0x3E8: ux0:app, vs0:app, gro0:app
+  0x3E9: ux0:patch
+  0x3EB: ?
+  0x3EA: ux0:addcont
+  0x3EC: ux0:theme
+  0x3ED: ux0:user/00/savedata
+  0x3EE: ur0:user/00/savedata
+  0x3EF: vs0:sys/external
+  0x3F0: vs0:data/external
+*/
+
+int known_pfs_ids[] = {
+  0x6E,
+  0x12E,
+  0x12F,
+  0x3ED,
+};
+
+int pfsMount(const char *path) {
+  int res;
+  char work_path[MAX_PATH_LENGTH];
+  char klicensee[0x10];
+  char license_buf[0x200];
+  ShellMountIdArgs args;
+
+  memset(klicensee, 0, sizeof(klicensee));
+
+/*
+  snprintf(work_path, MAX_PATH_LENGTH, "%ssce_sys/package/work.bin", path);
+  if (ReadFile(work_path, license_buf, sizeof(license_buf)) == sizeof(license_buf)) {
+    int res = shellUserGetRifVitaKey(license_buf, klicensee);
+    debugPrintf("read license: 0x%08X\n", res);
+  }
+*/
+  args.process_titleid = VITASHELL_TITLEID;
+  args.path = path;
+  args.desired_mount_point = NULL;
+  args.klicensee = klicensee;
+  args.mount_point = pfs_mount_point;
+
+  read_only = 0;
+
+  int i;
+  for (i = 0; i < sizeof(known_pfs_ids) / sizeof(int); i++) {
+    args.id = known_pfs_ids[i];
+
+    res = shellUserMountById(&args);
+    if (res >= 0)
+      return res;
+  }
+
+  read_only = 1;
+  return sceAppMgrGameDataMount(path, 0, 0, pfs_mount_point);
+}
+
+int pfsUmount() {
+  if (pfs_mount_point[0] == 0)
+    return -1;
+
+  int res = sceAppMgrUmount(pfs_mount_point);
+  if (res >= 0) {
+    memset(pfs_mount_point, 0, sizeof(pfs_mount_point));
+    memset(pfs_mounted_path, 0, sizeof(pfs_mounted_path));
+  }
+
+  return res;
+}

--- a/pfs.h
+++ b/pfs.h
@@ -1,0 +1,30 @@
+/*
+  VitaShell
+  Copyright (C) 2015-2018, TheFloW
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __PFS_H__
+#define __PFS_H__
+
+char pfs_mounted_path[MAX_PATH_LENGTH];
+char pfs_mount_point[MAX_MOUNT_POINT_LENGTH];
+int read_only;
+
+int known_pfs_ids[4];
+int pfsMount(const char *path);
+int pfsUmount();
+
+#endif

--- a/refresh.c
+++ b/refresh.c
@@ -29,7 +29,7 @@
 #include "language.h"
 #include "utils.h"
 #include "rif.h"
-//#include "pfs.c"
+#include "pfs.h"
 
 // Note: The promotion process is *VERY* sensitive to the directories used below
 // Don't change them unless you know what you are doing!

--- a/refresh.c
+++ b/refresh.c
@@ -106,17 +106,13 @@ int refreshNeeded(const char *app_path, const char* content_type)
   
   // Check if patch for installed app exists
   else if (strcmp(content_type, "patch") == 0) {
-    if (!checkAppExist(titleid)) {
-      debugPrintf("GAMEID: %s is not installed and does not need patch promotion", titleid);
+    if (!checkAppExist(titleid))
       return 0;
-    }
 	if (checkFileExist(sfo_path)) {
       snprintf(appmeta_path, MAX_PATH_LENGTH, "ux0:appmeta/%s", titleid);
-	  pfsUmount();
-      if(pfsMount(appmeta_path)<0) {
-		debugPrintf("pfsMount failed!");
+      pfsUmount();
+      if(pfsMount(appmeta_path)<0)
         return 0;
-	  }
       //Now read it
 	  snprintf(appmeta_param, MAX_PATH_LENGTH, "ux0:appmeta/%s/param.sfo", titleid);
       int sfo_size = allocateReadFile(appmeta_param, &sfo_buffer);
@@ -126,11 +122,8 @@ int refreshNeeded(const char *app_path, const char* content_type)
       getSfoString(sfo_buffer, "APP_VER", promoted_appver, sizeof(promoted_appver));
       pfsUmount();
 	  //Finally compare it
-	  debugPrintf("GAMEID: %s | APP_VER: %s | APPMETA_VER: %s | SFO_SIZE: %x\n", titleid, appver, promoted_appver);
-	  if (strcmp(appver, promoted_appver) == 0) {
-        debugPrintf("Appver and metaappver are the same! Skipping promotion!\n");
+	  if (strcmp(appver, promoted_appver) == 0)
 	    return 0;
-      }
     }
   }
   return 1;
@@ -169,7 +162,6 @@ int refreshApp(const char *app_path)
 
   // Promote vita app/vita dlc/vita patch (if needed)
   res = promoteApp(app_path);
-  debugPrintf("promoteApp: %s\n", app_path);
   return (res < 0) ? res : 1;
 }
 
@@ -315,8 +307,6 @@ void patch_callback(void* data, const char* dir, const char* subdir)
 {
   refresh_data_t *refresh_data = (refresh_data_t*)data;
   char path[MAX_PATH_LENGTH];
-  
-  debugPrintf("patch_callback_path: %s/%s\n", dir, subdir);
 
   if (refresh_data->refresh_pass) {
     snprintf(path, MAX_PATH_LENGTH, "%s/%s", dir, subdir);

--- a/refresh.c
+++ b/refresh.c
@@ -2,6 +2,7 @@
   VitaShell
   Copyright (C) 2015-2018, TheFloW
   Copyright (C) 2017, VitaSmith
+  Copyright (C) 2018, TheRadziu
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -34,6 +35,10 @@
 #define APP_TEMP "ux0:temp/app"
 #define DLC_TEMP "ux0:temp/addcont"
 
+// I dont know if those are correct directories but what the hell
+#define PSM_TEMP "ux0:temp/psm"
+#define THEME_TEMP "ux0:temp/theme"
+
 #define MAX_DLC_PER_TITLE 1024
 
 int isCustomHomebrew(const char* path)
@@ -50,11 +55,9 @@ int isCustomHomebrew(const char* path)
   return 1;
 }
 
-int refreshNeeded(const char *app_path)
+int refreshNeeded(const char *app_path, const char* content_type)
 {
   char sfo_path[MAX_PATH_LENGTH];
-  // TODO: Check app vs dlc from SFO
-  int res, is_app = (app_path[6] == 'p');
 
   // Read param.sfo
   snprintf(sfo_path, MAX_PATH_LENGTH, "%s/sce_sys/param.sfo", app_path);
@@ -80,18 +83,22 @@ int refreshNeeded(const char *app_path)
 
     // Check if bounded rif file exits
     _sceNpDrmGetRifName(rif_name, 0, aid);
-    if (is_app)
+    if (strcmp(content_type, "app") == 0)
       snprintf(sfo_path, MAX_PATH_LENGTH, "ux0:license/app/%s/%s", titleid, rif_name);
-    else
+    else if (strcmp(content_type, "theme") == 0)
+      snprintf(sfo_path, MAX_PATH_LENGTH, "ux0:license/theme/%s-%s/%s", titleid, &contentid[20], rif_name);
+    else if (strcmp(content_type, "dlc") == 0)
       snprintf(sfo_path, MAX_PATH_LENGTH, "ux0:license/addcont/%s/%s/%s", titleid, &contentid[20], rif_name);
     if (checkFileExist(sfo_path))
       return 0;
 
     // Check if fixed rif file exits
     _sceNpDrmGetFixedRifName(rif_name, 0, 0);
-    if (is_app)
+    if (strcmp(content_type, "app") == 0)
       snprintf(sfo_path, MAX_PATH_LENGTH, "ux0:license/app/%s/%s", titleid, rif_name);
-    else
+    else if (strcmp(content_type, "theme") == 0)
+      snprintf(sfo_path, MAX_PATH_LENGTH, "ux0:license/theme/%s-%s/%s", titleid, &contentid[20], rif_name);
+    else if (strcmp(content_type, "dlc") == 0)
       snprintf(sfo_path, MAX_PATH_LENGTH, "ux0:license/addcont/%s/%s/%s", titleid, &contentid[20], rif_name);
     if (checkFileExist(sfo_path))
       return 0;
@@ -131,7 +138,7 @@ int refreshApp(const char *app_path)
     free(sfo_buffer);
   }
 
-  // Promote app/dlc
+  // Promote vita app/vita dlc/theme
   res = promoteApp(app_path);
   return (res < 0) ? res : 1;
 }
@@ -197,7 +204,7 @@ void app_callback(void* data, const char* dir, const char* subdir)
 
   if (refresh_data->refresh_pass) {
     snprintf(path, MAX_PATH_LENGTH, "%s/%s", dir, subdir);
-    if (refreshNeeded(path)) {
+    if (refreshNeeded(path, "app")) {
       // Move the directory to temp for installation
       removePath(APP_TEMP, NULL);
       sceIoRename(path, APP_TEMP);
@@ -248,7 +255,7 @@ void dlc_callback_outer(void* data, const char* dir, const char* subdir)
     // 1. Move all dlc that require refresh out of addcont/title_id
     // 2. Refresh the moved dlc_data
     for (int i = 0; i < dlc_data.list_size; i++) {
-      if (refreshNeeded(dlc_data.list[i])) {
+      if (refreshNeeded(dlc_data.list[i], "dlc")) {
         snprintf(path, MAX_PATH_LENGTH, DLC_TEMP "/%s", &dlc_data.list[i][len + 1]);
         removePath(path, NULL);
         sceIoRename(dlc_data.list[i], path);
@@ -274,6 +281,32 @@ void dlc_callback_outer(void* data, const char* dir, const char* subdir)
   }
 }
 
+void theme_callback(void* data, const char* dir, const char* subdir)
+{
+  refresh_data_t *refresh_data = (refresh_data_t*)data;
+  char path[MAX_PATH_LENGTH];
+
+  if (strcasecmp(subdir, vitashell_titleid) == 0)
+    return;
+
+  if (refresh_data->refresh_pass) {
+    snprintf(path, MAX_PATH_LENGTH, "%s/%s", dir, subdir);
+    if (refreshNeeded(path, "theme")) {
+      // Move the directory to temp for installation
+      removePath(THEME_TEMP, NULL);
+      sceIoRename(path, THEME_TEMP);
+      if (refreshApp(THEME_TEMP) == 1)
+        refresh_data->refreshed++;
+      else
+        // Restore folder on error
+        sceIoRename(THEME_TEMP, path);
+    }
+    SetProgress(++refresh_data->processed, refresh_data->count);
+  } else {
+    refresh_data->count++;
+  }
+}
+
 int refresh_thread(SceSize args, void *argp) 
 {
   SceUID thid = -1;
@@ -294,12 +327,17 @@ int refresh_thread(SceSize args, void *argp)
   if (parse_dir_with_callback(SCE_S_IFDIR, "ux0:addcont", dlc_callback_outer, &refresh_data) < 0)
     goto EXIT;
 
+  // Get the theme count
+  if (parse_dir_with_callback(SCE_S_IFDIR, "ux0:theme", theme_callback, &refresh_data) < 0)
+    goto EXIT;
+
   // Update thread
   thid = createStartUpdateThread(refresh_data.count, 0);
 
   // Make sure we have the temp directories we need
   sceIoMkdir("ux0:temp", 0006);
   sceIoMkdir("ux0:temp/addcont", 0006);
+  sceIoMkdir("ux0:temp/theme", 0006);
   refresh_data.refresh_pass = 1;
 
   // Refresh apps
@@ -310,7 +348,12 @@ int refresh_thread(SceSize args, void *argp)
   if (parse_dir_with_callback(SCE_S_IFDIR, "ux0:addcont", dlc_callback_outer, &refresh_data) < 0)
     goto EXIT;
 
+  // Refresh theme
+  if (parse_dir_with_callback(SCE_S_IFDIR, "ux0:theme", theme_callback, &refresh_data) < 0)
+    goto EXIT;
+
   sceIoRmdir("ux0:temp/addcont");
+  sceIoRmdir("ux0:temp/theme");
 
   // Set progress to 100%
   sceMsgDialogProgressBarSetValue(SCE_MSG_DIALOG_PROGRESSBAR_TARGET_BAR_DEFAULT, 100);

--- a/refresh.c
+++ b/refresh.c
@@ -2,6 +2,7 @@
   VitaShell
   Copyright (C) 2015-2018, TheFloW
   Copyright (C) 2017, VitaSmith
+  Copyright (C) 2018, TheRadziu
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -28,11 +29,13 @@
 #include "language.h"
 #include "utils.h"
 #include "rif.h"
+//#include "pfs.c"
 
 // Note: The promotion process is *VERY* sensitive to the directories used below
 // Don't change them unless you know what you are doing!
 #define APP_TEMP "ux0:temp/app"
 #define DLC_TEMP "ux0:temp/addcont"
+#define PATCH_TEMP "ux0:temp/patch"
 #define PSM_TEMP "ux0:temp/psm"
 #define THEME_TEMP "ux0:temp/theme"
 
@@ -64,15 +67,16 @@ int refreshNeeded(const char *app_path, const char* content_type)
     return sfo_size;
 
   // Get title and content ids
-  char titleid[12], contentid[50];
+  char titleid[12], contentid[50], appver[8];
   getSfoString(sfo_buffer, "TITLE_ID", titleid, sizeof(titleid));
   getSfoString(sfo_buffer, "CONTENT_ID", contentid, sizeof(contentid));
+  getSfoString(sfo_buffer, "APP_VER", appver, sizeof(appver));
 
   // Free sfo buffer
   free(sfo_buffer);
 
-  // Check if app exists
-  if (checkAppExist(titleid)) {
+  // Check if app or dlc exists
+  if (((strcmp(content_type, "app") == 0)||(strcmp(content_type, "dlc") == 0))&&(checkAppExist(titleid))) {
     char rif_name[48];
 
     uint64_t aid;
@@ -93,6 +97,13 @@ int refreshNeeded(const char *app_path, const char* content_type)
       snprintf(sfo_path, MAX_PATH_LENGTH, "ux0:license/app/%s/%s", titleid, rif_name);
     else if (strcmp(content_type, "dlc") == 0)
       snprintf(sfo_path, MAX_PATH_LENGTH, "ux0:license/addcont/%s/%s/%s", titleid, &contentid[20], rif_name);
+    if (checkFileExist(sfo_path))
+      return 0;
+  }
+  
+  // Check if patch exists
+  else if ((strcmp(content_type, "patch") == 0)&&(!checkAppExist(titleid))) {
+    debugPrintf("GAMEID: %s | APP_VER: %s\n", titleid, appver);
     if (checkFileExist(sfo_path))
       return 0;
   }
@@ -131,8 +142,9 @@ int refreshApp(const char *app_path)
     free(sfo_buffer);
   }
 
-  // Promote vita app/vita dlc
+  // Promote vita app/vita dlc/vita patch (if needed)
   res = promoteApp(app_path);
+  debugPrintf("promoteApp: %s\n", app_path);
   return (res < 0) ? res : 1;
 }
 
@@ -274,6 +286,31 @@ void dlc_callback_outer(void* data, const char* dir, const char* subdir)
   }
 }
 
+void patch_callback(void* data, const char* dir, const char* subdir)
+{
+  refresh_data_t *refresh_data = (refresh_data_t*)data;
+  char path[MAX_PATH_LENGTH];
+  
+  debugPrintf("patch_callback_path: %s/%s\n", dir, subdir);
+
+  if (refresh_data->refresh_pass) {
+    snprintf(path, MAX_PATH_LENGTH, "%s/%s", dir, subdir);
+    if (refreshNeeded(path, "patch")) {
+      // Move the directory to temp for installation
+      removePath(PATCH_TEMP, NULL);
+      sceIoRename(path, PATCH_TEMP);
+      if (refreshApp(PATCH_TEMP) == 1)
+        refresh_data->refreshed++;
+      else
+        // Restore folder on error
+        sceIoRename(PATCH_TEMP, path);
+    }
+    SetProgress(++refresh_data->processed, refresh_data->count);
+  } else {
+    refresh_data->count++;
+  }
+}
+
 int refresh_thread(SceSize args, void *argp) 
 {
   SceUID thid = -1;
@@ -294,12 +331,17 @@ int refresh_thread(SceSize args, void *argp)
   if (parse_dir_with_callback(SCE_S_IFDIR, "ux0:addcont", dlc_callback_outer, &refresh_data) < 0)
     goto EXIT;
 
+  // Get the patch count
+  if (parse_dir_with_callback(SCE_S_IFDIR, "ux0:patch", patch_callback, &refresh_data) < 0)
+    goto EXIT;
+
   // Update thread
   thid = createStartUpdateThread(refresh_data.count, 0);
 
   // Make sure we have the temp directories we need
   sceIoMkdir("ux0:temp", 0006);
   sceIoMkdir("ux0:temp/addcont", 0006);
+  sceIoMkdir("ux0:temp/patch", 0006);
   refresh_data.refresh_pass = 1;
 
   // Refresh apps
@@ -309,8 +351,13 @@ int refresh_thread(SceSize args, void *argp)
   // Refresh dlc
   if (parse_dir_with_callback(SCE_S_IFDIR, "ux0:addcont", dlc_callback_outer, &refresh_data) < 0)
     goto EXIT;
+	
+  // Refresh patch
+  if (parse_dir_with_callback(SCE_S_IFDIR, "ux0:patch", patch_callback, &refresh_data) < 0)
+    goto EXIT;
 
   sceIoRmdir("ux0:temp/addcont");
+  sceIoRmdir("ux0:temp/patch");
 
   // Set progress to 100%
   sceMsgDialogProgressBarSetValue(SCE_MSG_DIALOG_PROGRESSBAR_TARGET_BAR_DEFAULT, 100);

--- a/refresh.c
+++ b/refresh.c
@@ -124,6 +124,7 @@ int refreshNeeded(const char *app_path, const char* content_type)
         return sfo_size;
       char promoted_appver[8];
       getSfoString(sfo_buffer, "APP_VER", promoted_appver, sizeof(promoted_appver));
+      pfsUmount();
 	  //Finally compare it
 	  debugPrintf("GAMEID: %s | APP_VER: %s | APPMETA_VER: %s | SFO_SIZE: %x\n", titleid, appver, promoted_appver);
 	  if (strcmp(appver, promoted_appver) == 0) {


### PR DESCRIPTION
Considered it as one of the missing core features of "Refresh Livearea" function, there is little explanation:
Till now only solution to match livearea appmeta (in that case mostly app_ver) with installed `ux0:patch` files was to either edit manually app_ver in app.db or to perform rebuild database. Both of these solutions were, in my opinion, unnecessary tasks to perform by the user. 

Now "Refresh Livearea" takes care about Patches too and if appmeta app_ver does not match patch app_ver, it will perform Patch promotion on it. 

This new patch support will be great for people who prefer to download latest updates through PC in mere minutes rather than wait hours till vita downloads it. [PSO2 updates for example, or any other 1gb+ updates]

edit: huge thanks to @dots-tb for giving me tips when I had troubles understanding how some basic stuff works in C :)