### PR TITLE
Fix build fault with new [buildtool patch][1]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,14 +39,22 @@ link_directories(
 # Builds
 FUNCTION(ADD_RESOURCES out_var)
   SET(result)
-  FOREACH(in_f ${ARGN})
-  SET(out_f "${CMAKE_CURRENT_BINARY_DIR}/${in_f}.o")
+  FOREACH(ref_f ${ARGN})
+  if (IS_ABSOLUTE "${ref_f}")
+    SET(out_f "${ref_f}.o")
+    STRING(REPLACE "${CMAKE_CURRENT_BINARY_DIR}/" "" in_f "${ref_f}")
+    SET(work_dir "${CMAKE_CURRENT_BINARY_DIR}")
+  else()
+    SET(out_f "${CMAKE_CURRENT_BINARY_DIR}/${ref_f}.o")
+    SET(in_f "${ref_f}")
+    SET(work_dir "${CMAKE_SOURCE_DIR}")
+  endif()
   GET_FILENAME_COMPONENT(out_dir ${out_f} DIRECTORY)
   ADD_CUSTOM_COMMAND(OUTPUT ${out_f}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${out_dir}
     COMMAND ${CMAKE_LINKER} -r -b binary -o ${out_f} ${in_f}
-    DEPENDS ${in_f}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS ${ref_f}
+    WORKING_DIRECTORY ${work_dir}
     COMMENT "Building resource ${out_f}"
     VERBATIM
     )
@@ -70,10 +78,10 @@ file(GLOB res_files RELATIVE
 # ugly hack
 add_resources(vitashell_res
   ${res_files}
-  build/modules/kernel/kernel.skprx
-  build/modules/user/user.suprx
-  build/modules/patch/patch.skprx
-  build/modules/usbdevice/usbdevice.skprx
+  ${CMAKE_CURRENT_BINARY_DIR}/modules/kernel/kernel.skprx
+  ${CMAKE_CURRENT_BINARY_DIR}/modules/user/user.suprx
+  ${CMAKE_CURRENT_BINARY_DIR}/modules/patch/patch.skprx
+  ${CMAKE_CURRENT_BINARY_DIR}/modules/usbdevice/usbdevice.skprx
 )
 
 add_executable(VitaShell
@@ -146,7 +154,7 @@ add_dependencies(VitaShell patch.skprx)
 add_dependencies(VitaShell usbdevice.skprx)
 
 target_link_libraries(VitaShell
-  ${CMAKE_CURRENT_BINARY_DIR}/modules/user/vitashell_user_stubs/libVitaShellUser_stub_weak.a
+  ${CMAKE_CURRENT_BINARY_DIR}/modules/user/libVitaShellUser_stub_weak.a
   ftpvita
   vita2d
   vorbisfile

--- a/init.c
+++ b/init.c
@@ -82,14 +82,14 @@ INCLUDE_EXTERN_RESOURCE(electron_settings_png);
 
 INCLUDE_EXTERN_RESOURCE(umass_skprx);
 
-extern unsigned char _binary_build_modules_kernel_kernel_skprx_start;
-extern unsigned char _binary_build_modules_kernel_kernel_skprx_size;
-extern unsigned char _binary_build_modules_user_user_suprx_start;
-extern unsigned char _binary_build_modules_user_user_suprx_size;
-extern unsigned char _binary_build_modules_patch_patch_skprx_start;
-extern unsigned char _binary_build_modules_patch_patch_skprx_size;
-extern unsigned char _binary_build_modules_usbdevice_usbdevice_skprx_start;
-extern unsigned char _binary_build_modules_usbdevice_usbdevice_skprx_size;
+extern unsigned char _binary_modules_kernel_kernel_skprx_start;
+extern unsigned char _binary_modules_kernel_kernel_skprx_size;
+extern unsigned char _binary_modules_user_user_suprx_start;
+extern unsigned char _binary_modules_user_user_suprx_size;
+extern unsigned char _binary_modules_patch_patch_skprx_start;
+extern unsigned char _binary_modules_patch_patch_skprx_size;
+extern unsigned char _binary_modules_usbdevice_usbdevice_skprx_start;
+extern unsigned char _binary_modules_usbdevice_usbdevice_skprx_size;
 
 #define DEFAULT_FILE(path, name, replace) { path, (void *)&_binary_resources_##name##_start, (int)&_binary_resources_##name##_size, replace }
 
@@ -149,14 +149,14 @@ static DefaultFile default_files[] = {
 
   DEFAULT_FILE("ux0:VitaShell/module/umass.skprx", umass_skprx, 1),
   
-  { "ux0:VitaShell/module/kernel.skprx",    (void *)&_binary_build_modules_kernel_kernel_skprx_start,
-                                               (int)&_binary_build_modules_kernel_kernel_skprx_size, 1 },
-  { "ux0:VitaShell/module/user.suprx",      (void *)&_binary_build_modules_user_user_suprx_start,
-                                               (int)&_binary_build_modules_user_user_suprx_size, 1 },
-  { "ux0:VitaShell/module/patch.skprx",     (void *)&_binary_build_modules_patch_patch_skprx_start,
-                                               (int)&_binary_build_modules_patch_patch_skprx_size, 1 },
-  { "ux0:VitaShell/module/usbdevice.skprx", (void *)&_binary_build_modules_usbdevice_usbdevice_skprx_start,
-                                               (int)&_binary_build_modules_usbdevice_usbdevice_skprx_size, 1 },
+  { "ux0:VitaShell/module/kernel.skprx",    (void *)&_binary_modules_kernel_kernel_skprx_start,
+                                               (int)&_binary_modules_kernel_kernel_skprx_size, 1 },
+  { "ux0:VitaShell/module/user.suprx",      (void *)&_binary_modules_user_user_suprx_start,
+                                               (int)&_binary_modules_user_user_suprx_size, 1 },
+  { "ux0:VitaShell/module/patch.skprx",     (void *)&_binary_modules_patch_patch_skprx_start,
+                                               (int)&_binary_modules_patch_patch_skprx_size, 1 },
+  { "ux0:VitaShell/module/usbdevice.skprx", (void *)&_binary_modules_usbdevice_usbdevice_skprx_start,
+                                               (int)&_binary_modules_usbdevice_usbdevice_skprx_size, 1 },
 };
 
 char vitashell_titleid[12];

--- a/modules/user/CMakeLists.txt
+++ b/modules/user/CMakeLists.txt
@@ -25,7 +25,7 @@ add_executable(user
 add_dependencies(user vitashell_kernel_stubs)
 
 target_link_libraries(user
-  ${CMAKE_CURRENT_BINARY_DIR}/../kernel/vitashell_kernel_stubs/libVitaShellKernel2_stub.a
+  ${CMAKE_CURRENT_BINARY_DIR}/../kernel/libVitaShellKernel2_stub.a
   SceLibKernel_stub
   SceIofilemgr_stub
 )


### PR DESCRIPTION
- partialy support building with ninja; need to fix `release` and `send`
- detection module path using CMAKE_BINARY_DIR; but dirty hack

[1]: https://github.com/vitasdk/vita-toolchain/commit/4545e75e6